### PR TITLE
[bugfix] remove previously added quotes in help command

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -16,7 +16,7 @@
 
 ## -- Help Context
 show_help() {
-cat << 'EOF'
+cat << EOF
 
 Usage: ${0##*/} [-h] [ [-m] manifest || [-p] preset ] [-k] parentkey [-P] keypath [-a] helm_args [-M]
     -m [manifest]      Manifest Name

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "manifests"
-version: "0.1.1"
+version: "0.1.2"
 usage: "Get Manifest Values"
 description: "Get Manifest Values"
 ignoreFlags: false


### PR DESCRIPTION
**What this PR does**:
Remove the previously added quotes, as they cause the expression in the help command to not be evaluated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Notes for Reviewer**:

**Checklist**:
- [x] Version bumped
- [x] All commits are signed-off